### PR TITLE
added front-end to CORS

### DIFF
--- a/impactreeproject/settings.py
+++ b/impactreeproject/settings.py
@@ -46,7 +46,7 @@ CORS_ORIGIN_WHITELIST = (
     "http://127.0.0.1:3000",
     "http://localhost:5173",
     "http://127.0.0.1:5173",
-    "https://impactree-client-wzoz9.ondigitalocean.app",
+    "https://impactree-941477901286.us-central1.run.app",
 )
 
 


### PR DESCRIPTION
This pull request updates the list of allowed CORS origins in the `impactreeproject/settings.py` file to reflect a change in the deployed client application URL.

Configuration update:

* Replaced the previous production client URL with the new deployment endpoint (`https://impactree-941477901286.us-central1.run.app`) in the CORS origins list.